### PR TITLE
Don't cast result collection types when building it

### DIFF
--- a/src/Xapu.Extensions.Selects/Core/ExpressionBuilders/CollectionMapperExpressionBuilder.cs
+++ b/src/Xapu.Extensions.Selects/Core/ExpressionBuilders/CollectionMapperExpressionBuilder.cs
@@ -46,7 +46,7 @@ namespace Xapu.Extensions.Selects
             if (resultType.IsArray)
                 return BuildArrayExpression(expression, resultType);
             else
-                return BuildDefaultCollectionTypeExpression(expression, resultType);
+                return BuildListExpression(expression, resultType);
         }
 
         private static bool NeedCasting(Type resultType)
@@ -64,30 +64,12 @@ namespace Xapu.Extensions.Selects
             return Expression.Call(toArrayMethod, expression);
         }
 
-        private static Expression BuildDefaultCollectionTypeExpression(MethodCallExpression expression, Type resultType)
-        {
-            var resultList = BuildListExpression(expression, resultType);
-
-            if (IsList(resultType))
-                return resultList;
-
-            // To give the final func the correct signature
-            return Expression.TypeAs(resultList, resultType);
-        }
-
         private static Expression BuildListExpression(MethodCallExpression expression, Type resultType)
         {
             var elementType = resultType.GetCollectionElementType();
             var toListMethod = ToListMethodInfo.MakeGenericMethod(elementType);
 
             return Expression.Call(toListMethod, expression);
-        }
-
-        private static bool IsList(Type resultType)
-        {
-            var elementType = resultType.GetCollectionElementType();
-
-            return resultType == typeof(List<>).MakeGenericType(elementType);
         }
     }
 }

--- a/src/Xapu.Extensions.Selects/Core/ExpressionBuilders/MapperExpressionBuilder.cs
+++ b/src/Xapu.Extensions.Selects/Core/ExpressionBuilders/MapperExpressionBuilder.cs
@@ -52,7 +52,17 @@ namespace Xapu.Extensions.Selects
 
             var sourceIsNull = Expression.Equal(sourceLocalName, Expression.Default(sourceType));
             var defaultResultValue = Expression.Default(resultType);
-            return Expression.Condition(sourceIsNull, defaultResultValue, resultValue);
+            var castedResultValue = ResolveResultValueCasting(resultValue, resultType);
+
+            return Expression.Condition(sourceIsNull, defaultResultValue, castedResultValue);
+        }
+
+        private static Expression ResolveResultValueCasting(Expression resultValue, Type resultType)
+        {
+            if (resultValue.Type == resultType)
+                return resultValue;
+            else
+                return Expression.TypeAs(resultValue, resultType);
         }
     }
 }


### PR DESCRIPTION
The type casting was causing problems with IQueryables.
The only reason for that casting is to be able to build the conditional used for null guards, which isn't even used for IQueryables.
Also, seems like a better design to have the null guard logic doing the casting, since it is the thing that needs it anyways.